### PR TITLE
Update RuntimeUITestFixture test with panelRenderer support

### DIFF
--- a/Assets/Tests/Runtime/B07_Pause/PauseScreenRuntimeTests.cs
+++ b/Assets/Tests/Runtime/B07_Pause/PauseScreenRuntimeTests.cs
@@ -25,8 +25,9 @@ namespace Bagel.B07_Pause
         {
             m_PlayManager = Object.FindFirstObjectByType<PlayManager>(FindObjectsInactive.Include);
             var driver = Object.FindFirstObjectByType<PauseScreenDriver>(FindObjectsInactive.Include);
-            var doc = driver.GetComponent<UIDocument>();
-            SetUIContent(doc);
+            var panelRenderer = driver.GetComponent<PanelRenderer>();
+
+            SetPanelRenderer(panelRenderer);
         }
 
         [UnityTest]


### PR DESCRIPTION
This PR updates the PauseScreenRuntimeTests to use the latest PanelRenderer support from UI Test Framework.